### PR TITLE
Fix removeChat()'s `uid` check

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -51,7 +51,7 @@ export async function removeChat({ id, path }: { id: string; path: string }) {
 
   const uid = await kv.hget<string>(`chat:${id}`, 'userId')
 
-  if (uid !== session?.user?.id) {
+  if (uid != session?.user?.id) {
     return {
       error: 'Unauthorized'
     }


### PR DESCRIPTION
This allows to remove chats.
`uid` will be a Number, while `session.user.id` a String. If checked with `!==` it will always fail.